### PR TITLE
call x and y accessors with i as second parameter

### DIFF
--- a/src/linear.js
+++ b/src/linear.js
@@ -16,8 +16,8 @@ export default function(){
         maxX = domain ? +domain[1] : -Infinity;
 
     for (let i = 0; i < n; i++){
-      const dx = x(data[i]),
-          dy = y(data[i]);
+      const dx = x(data[i], i),
+          dy = y(data[i], i);
       xSum += dx;
       ySum += dy;
       xySum += dx * dy;


### PR DESCRIPTION
There are some situations such as discrete x-axis values where it is useful for the accessor function to receive the current loop index. Probably all d3-regression files should be changed, but here is a quick PR for linear.js.