### PR TITLE
Don't let median modify the input array

### DIFF
--- a/src/utils/median.js
+++ b/src/utils/median.js
@@ -1,5 +1,6 @@
 // Returns the medium value of an array of numbers.
-export function median(arr){
+export function median(inarr){
+  let arr = inarr.slice();  // copy so median doesn't modify input
   arr.sort((a, b) => a - b);
   var i = arr.length / 2;
   return i % 1 === 0 ? (arr[i - 1] + arr[i]) / 2 : arr[Math.floor(i)];


### PR DESCRIPTION
As far as I can tell, loess regression is the only client, and it expects the input array not to be modified when it calls median. Without this change, the non-optional robustness passes are just adding noise, I think. I checked the science.js and vega versions and they are already using non-destructive median functions.