### PR TITLE
Fix incorrect license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "main": "dist/d3-regression.js",
   "module": "index",
-  "license": "GPL-3.0",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/HarryStevens/d3-regression/issues"
   },


### PR DESCRIPTION
For a project at Amazon, I want to use G2Plot (https://github.com/antvis/g2plot/), which depends on this package. Unfortunately I can't do this, because the package.json has configured GPL-3 as the license for this package.

However, it seems this was a mistake, because the actual license file contains a BSD-3-Clause license.

Therefore I propose to fix this in the package.json as well.