### PR TITLE
Passes the index of each data object to x/y accessors.

### DIFF
--- a/dist/d3-regression.cjs.js
+++ b/dist/d3-regression.cjs.js
@@ -45,9 +45,9 @@ function _nonIterableRest() {
 // License: https://github.com/vega/vega/blob/f058b099decad9db78301405dd0d2e9d8ba3d51a/LICENSE
 // Source: https://github.com/vega/vega/blob/f058b099decad9db78301405dd0d2e9d8ba3d51a/packages/vega-statistics/src/regression/points.js
 function points(data, x, y, sort) {
-  data = data.filter(function (d) {
-    var u = x(d),
-        v = y(d);
+  data = data.filter(function (d, i) {
+    var u = x(d, i),
+        v = y(d, i);
     return u != null && isFinite(u) && v != null && isFinite(v);
   });
 
@@ -69,8 +69,8 @@ function points(data, x, y, sort) {
 
   for (var i = 0; i < n;) {
     d = data[i];
-    X[i] = xv = +x(d);
-    Y[i] = yv = +y(d);
+    X[i] = xv = +x(d, i);
+    Y[i] = yv = +y(d, i);
     ++i;
     ux += (xv - ux) / i;
     uy += (yv - uy) / i;
@@ -89,8 +89,8 @@ function visitPoints(data, x, y, cb) {
 
   for (var i = 0, n = data.length; i < n; i++) {
     var d = data[i],
-        dx = +x(d),
-        dy = +y(d);
+        dx = +x(d, i),
+        dy = +y(d, i);
 
     if (dx != null && isFinite(dx) && dy != null && isFinite(dy)) {
       cb(dx, dy, iterations++);

--- a/dist/d3-regression.esm.js
+++ b/dist/d3-regression.esm.js
@@ -41,9 +41,9 @@ function _nonIterableRest() {
 // License: https://github.com/vega/vega/blob/f058b099decad9db78301405dd0d2e9d8ba3d51a/LICENSE
 // Source: https://github.com/vega/vega/blob/f058b099decad9db78301405dd0d2e9d8ba3d51a/packages/vega-statistics/src/regression/points.js
 function points(data, x, y, sort) {
-  data = data.filter(function (d) {
-    var u = x(d),
-        v = y(d);
+  data = data.filter(function (d, i) {
+    var u = x(d, i),
+        v = y(d, i);
     return u != null && isFinite(u) && v != null && isFinite(v);
   });
 
@@ -65,8 +65,8 @@ function points(data, x, y, sort) {
 
   for (var i = 0; i < n;) {
     d = data[i];
-    X[i] = xv = +x(d);
-    Y[i] = yv = +y(d);
+    X[i] = xv = +x(d, i);
+    Y[i] = yv = +y(d, i);
     ++i;
     ux += (xv - ux) / i;
     uy += (yv - uy) / i;
@@ -85,8 +85,8 @@ function visitPoints(data, x, y, cb) {
 
   for (var i = 0, n = data.length; i < n; i++) {
     var d = data[i],
-        dx = +x(d),
-        dy = +y(d);
+        dx = +x(d, i),
+        dy = +y(d, i);
 
     if (dx != null && isFinite(dx) && dy != null && isFinite(dy)) {
       cb(dx, dy, iterations++);

--- a/dist/d3-regression.js
+++ b/dist/d3-regression.js
@@ -47,9 +47,9 @@
   // License: https://github.com/vega/vega/blob/f058b099decad9db78301405dd0d2e9d8ba3d51a/LICENSE
   // Source: https://github.com/vega/vega/blob/f058b099decad9db78301405dd0d2e9d8ba3d51a/packages/vega-statistics/src/regression/points.js
   function points(data, x, y, sort) {
-    data = data.filter(function (d) {
-      var u = x(d),
-          v = y(d);
+    data = data.filter(function (d, i) {
+      var u = x(d, i),
+          v = y(d, i);
       return u != null && isFinite(u) && v != null && isFinite(v);
     });
 
@@ -71,8 +71,8 @@
 
     for (var i = 0; i < n;) {
       d = data[i];
-      X[i] = xv = +x(d);
-      Y[i] = yv = +y(d);
+      X[i] = xv = +x(d, i);
+      Y[i] = yv = +y(d, i);
       ++i;
       ux += (xv - ux) / i;
       uy += (yv - uy) / i;
@@ -91,8 +91,8 @@
 
     for (var i = 0, n = data.length; i < n; i++) {
       var d = data[i],
-          dx = +x(d),
-          dy = +y(d);
+          dx = +x(d, i),
+          dy = +y(d, i);
 
       if (dx != null && isFinite(dx) && dy != null && isFinite(dy)) {
         cb(dx, dy, iterations++);

--- a/src/utils/points.js
+++ b/src/utils/points.js
@@ -2,8 +2,8 @@
 // License: https://github.com/vega/vega/blob/f058b099decad9db78301405dd0d2e9d8ba3d51a/LICENSE
 // Source: https://github.com/vega/vega/blob/f058b099decad9db78301405dd0d2e9d8ba3d51a/packages/vega-statistics/src/regression/points.js
 export function points(data, x, y, sort) {
-  data = data.filter(d => {
-    let u = x(d), v = y(d);
+  data = data.filter((d, i) => {
+    let u = x(d, i), v = y(d, i);
     return u != null && isFinite(u) && v != null && isFinite(v);
   });
 
@@ -19,8 +19,8 @@ export function points(data, x, y, sort) {
   let ux = 0, uy = 0, xv, yv, d;
   for (let i = 0; i < n; ) {
     d = data[i];
-    X[i] = xv = +x(d);
-    Y[i] = yv = +y(d);
+    X[i] = xv = +x(d, i);
+    Y[i] = yv = +y(d, i);
     ++i;
     ux += (xv - ux) / i;
     uy += (yv - uy) / i;
@@ -41,9 +41,9 @@ export function visitPoints(data, x, y, cb){
 
   for (let i = 0, n = data.length; i < n; i++) {
     const d = data[i],
-          dx = +x(d),
-          dy = +y(d);
-    
+          dx = +x(d, i),
+          dy = +y(d, i);
+
     if (dx != null && isFinite(dx) && dy != null && isFinite(dy)) {
       cb(dx, dy, iterations++);
     }


### PR DESCRIPTION
It looks like this was added at one point for linear regressions
(1b71ab6cfda5b4c6f0446d493a64bece57d8b960), but was lost when all
regressions started using visit points.